### PR TITLE
Clarify that four-word limit applies to each, not all, GCP services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 # The Google Cloud Developer's Cheat Sheet
-Every product in the Google Cloud family described in <=4 words (with liberal use of hyphens and slashes :smirk:)\
+Each product in the Google Cloud family described in <=4 words (with liberal use of hyphens and slashes :smirk:)\
 by the Google Developer Relations Team\
 <a target="_blank" href="DarkPoster-medres.png"><img border="1" alt="Google Cloud Developer's Cheat Sheet Poster Image" src="DarkPoster-lowres.png"></a>\
 White background:


### PR DESCRIPTION
The word "every" here may imply to some that a total of four words will be used to describe *every* service in the Google Cloud suite.  This can be worded a bit more directly by stating instead that "each" of them is described in four or fewer words.